### PR TITLE
feat(css-normalize): update package

### DIFF
--- a/.changeset/wild-suns-count.md
+++ b/.changeset/wild-suns-count.md
@@ -1,0 +1,5 @@
+---
+"@toolbox-ts/css-normalize": minor
+---
+
+add css compilation to reduce redundancy and improve semantic organization, add weight prefix to font weight vars (--weight-\*), section/organize css file, updates docs, update build process, add default styling to more elements.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 **/LICENSE*
 **/*.md/**
+**/normalize.*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,16 +13,16 @@
   "better-comments.multilineComments": true,
   "better-comments.tags": [
     {
-      "tag": "#region>Meta",
-      "color": "#9d78e0",
+      "tag": "#region>",
+      "color": "#31EA56",
       "strikethrough": false,
       "underline": true,
       "bold": true,
       "italic": true
     },
     {
-      "tag": "#endregionM",
-      "color": "#4f3c73",
+      "tag": "#endregion",
+      "color": "#195226",
       "strikethrough": false,
       "underline": false,
       "bold": true,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "husky": "^9.1.7",
     "inquirer": "^12.6.0",
     "jiti": "^2.4.2",
+    "lightningcss": "^1.29.3",
     "lint-staged": "^15.5.2",
     "memfs": "^4.17.1",
     "prettier": "^3.5.3",

--- a/packages/css-normalize/README.md
+++ b/packages/css-normalize/README.md
@@ -225,15 +225,14 @@ foundation.
   --border-width: 1px;
 
   /* === Font Weights === */
-  --thin: 100;
-  --extra-light: 200;
-  --light: 300;
-  --normal: 400;
-  --medium: 500;
-  --semi-bold: 500;
-  --bold: 600;
-  --extra-bold: 700;
-  --black: 900;
+  --weight-thin: 100;
+  --weight-extra-light: 200;
+  --weight-light: 300;
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-bold: 600;
+  --weight-extra-bold: 700;
+  --weight-black: 900;
 
   /* === Outline === */
   --outline-width: 2px;

--- a/packages/css-normalize/bin/build.ts
+++ b/packages/css-normalize/bin/build.ts
@@ -1,21 +1,27 @@
 #!/usr/bin/env node
 import fs from "fs";
 import path from "path";
+import { transform } from "lightningcss";
 
 const __dirname = import.meta.dirname;
-const sourceStaticPath = path.join(__dirname, "../src/static");
-const cssPath = path.join(__dirname, "../src/static/normalize.css");
-const buildPath = path.join(__dirname, "../build/static");
-fs.mkdirSync(buildPath, { recursive: true });
+const sourceCssPath = path.join(__dirname, "../src/static/normalize.css");
+const buildStaticPath = path.join(__dirname, "../build/static");
+fs.mkdirSync(buildStaticPath, { recursive: true });
+const css = fs.readFileSync(sourceCssPath, "utf-8").replace(/`/g, "\\`");
+const compiledCss = transform({
+  filename: "normalize.css",
+  code: Buffer.from(css),
+  minify: true,
+}).code.toString();
 
-const css = fs.readFileSync(cssPath, "utf-8").replace(/`/g, "\\`");
-
-fs.writeFileSync(`${buildPath}/string.js`, `export default \`${css}\``);
-
-fs.cpSync(sourceStaticPath, buildPath, { recursive: true });
+fs.writeFileSync(path.join(buildStaticPath, "normalize.css"), compiledCss);
+fs.writeFileSync(
+  `${buildStaticPath}/string.js`,
+  `export default \`${compiledCss}\``,
+);
 
 ["scss", "pcss", "less", "styl"].forEach((ext) => {
-  fs.writeFileSync(`${buildPath}/normalize.${ext}`, css);
+  fs.writeFileSync(`${buildStaticPath}/normalize.${ext}`, compiledCss);
 });
 fs.appendFileSync(
   path.join(__dirname, "../build/index.js"),

--- a/packages/css-normalize/example.html
+++ b/packages/css-normalize/example.html
@@ -10,7 +10,7 @@
     <header>
       <h1>normalize.css Example &amp; Showcase</h1>
       <p>
-        This page demonstrates the
+        <mark>MARKED This page demonstrates the</mark>
         <strong>default browser behavior</strong> after applying
         <code>normalize.css</code>.<br />
       </p>

--- a/packages/css-normalize/src/modules/vars/define/__define.test.ts
+++ b/packages/css-normalize/src/modules/vars/define/__define.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { define } from "./define";
-
 // Helper: get a valid key for each top-level cssProps section
 const getValidInput = () => ({
   font: { family: "Arial", weight: { bold: "700", thin: "100" } },
@@ -19,8 +18,8 @@ describe("define", () => {
 
     // Check for a few expected outputs
     expect(css).toContain("--font-family: Arial;");
-    expect(css).toContain("--font-weight-bold: 700;");
-    expect(css).toContain("--font-weight-thin: 100;");
+    expect(css).toContain("--weight-bold: 700;");
+    expect(css).toContain("--weight-thin: 100;");
     expect(css).toContain("--spacing-sm: 4px;");
     expect(css).toContain("--border-border: 1px solid red;");
     expect(css).toContain("--transition-duration: 0.3s;");

--- a/packages/css-normalize/src/static/normalize.css
+++ b/packages/css-normalize/src/static/normalize.css
@@ -1,42 +1,21 @@
+/* prettier-ignore */
 /*! Adapted from modern-normalize v3.0.1 | MIT License | https://github.com/sindresorhus/modern-normalize */
 
-/*  -webkit
- *  1. Remove the inner padding in Chrome and Safari on macOS. 
- *  2. Correct the cursor style of increment and decrement buttons in Safari.
- *  3. Correct the inability to style clickable types in iOS and Safari.
- *  4. Change font properties to 'inherit' in Safari.
-*/
-::-webkit-search-decoration {
-  -webkit-appearance: none;
-} /* 1 */
-::-webkit-inner-spin-button,
-::-webkit-outer-spin-button {
-  height: auto;
-} /* 2 */
-::-webkit-file-upload-button {
-  -webkit-appearance: button; /* 3 */
-  font: inherit; /* 4 */
-}
-[type="search"] {
-  /* Correct the odd appearance in Chrome and Safari */
-  -webkit-appearance: textfield;
-  appearance: textfield;
-  /* Correct the outline style in Safari. */
-  outline-offset: -2px;
-}
+/* Enforce preferred box model */
+*, *::after, *::before { box-sizing: border-box; }
 
-/* Root and Document */
-html, body, 
+/*#region> Primary Reset */
+html, body,
 /* Sectioning */
-main, article, section, nav, 
-aside, header, footer, hgroup, 
+div, span, main, article, section,
+nav, aside, header, footer, hgroup, 
 /* Headings */
 h1, h2, h3, h4, h5, h6, 
 /* Text-level Semantics */
 p, a, q, s, b, u, i, address, strong, 
 samp, big, cite, code, del, dfn, blockquote, 
 pre, wbr, abbr, acronym, em, ins, kbd,  
-small, strike, sub, sup, tt, var, center, 
+small, strike, sub, sup, tt, var, center,
 mark, bdi, bdo, data, time, output, meter, 
 /* Embedded Content */
 img, picture, canvas, svg, object, 
@@ -58,9 +37,7 @@ details, summary, dialog,
 /* Figure */
 figure, figcaption, 
 /* Ruby Annotations */
-ruby, rt, rp, 
-/* Misc */
-div, span {
+ruby, rt, rp {
   margin: 0;
   padding: 0;
   border: none;
@@ -69,58 +46,137 @@ div, span {
   color: inherit;
 }
 /* Ensure Semantic Flow tags default to Block */
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-main,
-menu,
-nav,
-section {
-  display: block;
-}
-fieldset {
-  min-width: 0;
-}
-*,
-*::after,
-*::before {
-  box-sizing: border-box;
+article, aside, details,
+figcaption, figure, footer,
+header, main, menu, nav, section { display: block; }
+fieldset { min-width: 0; }
+/* Add the correct display in Chrome and Safari.  */
+summary { 
+  display: list-item; 
+  &:focus{ outline: var(--outline); }
 }
 
+/* -webkit 
+ *  1. Correct the cursor style of increment and decrement buttons in Safari.
+ *  2. Correct the inability to style clickable types in iOS and Safari.
+ *  3. Change font properties to 'inherit' in Safari.
+*/
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button { height: auto; } /* 2 */ 
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 3 */
+  font: inherit; /* 4 */
+}
+
+[type='search'] {
+  /* Correct the odd appearance in Chrome and Safari */
+  -webkit-appearance: textfield;
+  appearance: textfield;
+  /* Correct the outline style in Safari. */
+  outline-offset: -2px;
+}
+/*#endregion*/
+
+/*#region> Layout */
+html {
+  font-family: var(--font-family);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-base);
+  letter-spacing: var(--letter-spacing);
+  cursor: auto;
+  tab-size: 4;
+  /* Prevent adjustments of font size after orientation changes in iOS. */
+  -webkit-text-size-adjust: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow-y: scroll;
+  text-rendering: optimizeLegibility;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  scroll-behavior: smooth;
+  scrollbar-gutter: stable both-edges;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) var(--color-bg);
+}
+body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  transition:
+    background-color var(--transition-duration) ease,
+    color var(--transition-duration) ease;
+  background-color: var(--color-bg);
+  color: var(--color-fg);
+}
+main {
+  flex: 1;
+}
+/*#endregion*/
+
+/*#region> Typography */
 /* Prevent 'sub' and 'sup' elements from affecting the line height in all browsers. */
-sub,
-sup {
+sub, sup {
   font-size: 75%;
   line-height: 0;
   position: relative;
 }
-sub {
-  bottom: -0.25em;
+sub { bottom: -0.25em; }
+sup { top: -0.5em; }
+b,strong { font-weight: var(--weight-bold); }
+small { font-size: 80%; }
+blockquote, q { quotes: none;}
+code, kbd, samp, pre {
+  font-family: var(--font-family-mono);
+  font-size: 1em;
+  font-weight: var(--weight-normal);
+  letter-spacing: 0;
 }
-sup {
-  top: -0.5em;
+h1 { font-size: 2.25rem; }
+h2 { font-size: 1.5rem; }
+h3 { font-size: 1.25rem; }
+h4 { font-size: 1.125rem; }
+h5 { font-size: 1rem; }
+h6 { font-size: 0.875rem; }
+h1, h2, h3,
+h4, h5, h6 {
+  font-weight: var(--weight-bold);
+  line-height: 1.2;
 }
-b,
-strong {
-  font-weight: bolder;
+mark {
+  background-color: var(--color-accent); 
+  color:var(--color-bg);
+  padding: 0.125em 0.25em;
+  border-radius:  0.125rem;
+  user-select: text;
+  cursor: text;
+  font-weight: var(--weight-medium);
+  &::selection {
+    background-color: var(--color-fg);
+    color: var(--color-bg);
+  }
 }
-small {
-  font-size: 80%;
+::selection {
+  background-color: var(--color-accent);
+  color: var(--color-bg);
+  text-shadow: none;
+  user-select: text;
+  cursor: text;
+  font-weight: var(--weight-medium);
 }
 
+/*#endregion*/
+
+/*#region> :root variable definitions */
 :root {
   --font-family:
-    "Ubuntu", "Segoe UI", "Roboto", "Helvetica Neue", sans-serif, system-ui,
-    "Apple Color Emoji", "Segoe UI Emoji";
+    'Ubuntu', 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif, system-ui,
+    'Apple Color Emoji', 'Segoe UI Emoji';
   --font-family-mono:
-    "Ubuntu Mono", "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
-  --line-height: 1.5;
+    'Ubuntu Mono', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
   --letter-spacing: 0.01em;
-  --font-size: 20px;
+  --line-height-base: 1.5;
+  --font-size-base: 20px;
 
   --transition-duration: 0.1s;
 
@@ -135,15 +191,14 @@ small {
   --color-border: var(--light-color-border);
   --border: var(--border-width) solid var(--color-border);
 
-  --thin: 100;
-  --extra-light: 200;
-  --light: 300;
-  --normal: 400;
-  --medium: 500;
-  --semi-bold: 500;
-  --bold: 600;
-  --extra-bold: 700;
-  --black: 900;
+  --weight-thin: 100;
+  --weight-extra-light: 200;
+  --weight-light: 300;
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-bold: 600;
+  --weight-extra-bold: 700;
+  --weight-black: 900;
 
   --outline-width: 2px;
   --color-outline: var(--light-color-outline);
@@ -154,7 +209,7 @@ small {
 
   --elevation-low: 0 var(--elevation-base-y-offset) var(--elevation-base-blur)
     var(--color-shadow);
-  --elevation-medium: 0 calc(var(--elevation-base-y-offset) * var(2))
+  --elevation-medium: 0 calc(var(--elevation-base-y-offset) * 2)
     calc(var(--elevation-base-blur) * 2) var(--color-shadow);
   --elevation-high: 0 calc(var(--elevation-base-y-offset) * 4)
     calc(var(--elevation-base-blur) * 4) var(--color-shadow);
@@ -185,7 +240,7 @@ small {
   --dark-color-muted: #c9b8d1;
   --dark-color-border: var(--dark-color-emphasis);
   --dark-color-outline: var(--dark-color-emphasis);
-  --dark-shadow-color: var(--dark-color-emphasis);
+  --dark-color-shadow: var(--dark-color-emphasis);
 
   --color-bg: var(--light-color-bg);
   --color-fg: var(--light-color-fg);
@@ -193,85 +248,16 @@ small {
   --color-accent: var(--light-color-accent);
   --color-emphasis: var(--light-color-emphasis);
   --color-muted: var(--light-color-muted);
-
   --color-shadow: var(--light-color-shadow);
 }
+/*#endregion*/
 
-h1 {
-  font-size: 2.25rem;
-}
-
-h2 {
-  font-size: 1.5rem;
-}
-h3 {
-  font-size: 1.25rem;
-}
-h4 {
-  font-size: 1.125rem;
-}
-h5 {
-  font-size: 1rem;
-}
-h6 {
-  font-size: 0.875rem;
-}
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-weight: var(--bold);
-  line-height: 1.2;
-}
-hr {
-  border-top: var(--border);
-  width: 100%;
-}
-code,
-kbd,
-samp,
-pre {
-  font-family: var(--font-family-mono);
-  font-size: 1em;
-  font-weight: normal;
-  letter-spacing: 0;
-}
-
-html {
-  font-family: var(--font-family);
-  font-size: var(--font-size);
-  line-height: var(--line-height);
-  letter-spacing: var(--letter-spacing);
-  cursor: auto;
-  tab-size: 4;
-  /* Prevent adjustments of font size after orientation changes in iOS. */
-  -webkit-text-size-adjust: 100%;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  overflow-y: scroll;
-  text-rendering: optimizeLegibility;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  scroll-behavior: smooth;
-  scrollbar-gutter: stable both-edges;
-}
-
-body {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  transition:
-    background-color var(--transition-duration) ease,
-    color var(--transition-duration) ease;
-  background-color: var(--color-bg);
-  color: var(--color-fg);
-}
-
-main {
-  flex: 1;
+/*#region> Interactives */
+*:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  pointer-events: none;
+  color: var(--color-muted);
 }
 
 button,
@@ -280,45 +266,28 @@ select,
 option,
 video,
 details > summary,
-[role="button"],
-[type="button"],
-[type="reset"],
-[type="submit"],
 label[for],
-input[type="checkbox"],
-input[type="radio"],
-input[type="file"],
-input[type="range"],
-input[type="color"],
-input[type="image"] {
-  cursor: pointer;
-}
-
-input,
-textarea {
-  &:focus {
-    outline: var(--outline);
-  }
-  &:hover,
-  &:active {
+[role='button'],
+[type='button'],
+[type='reset'],
+[type='submit'],
+[type='checkbox'],
+[type='radio'],
+[type='file'],
+[type='range'],
+[type='color'],
+[type='image'],
+[type='number'] { cursor: pointer; }
+input, textarea {
+  &:focus { outline: var(--outline); }
+  &:hover, &:active {
     border-color: var(--color-primary);
     box-shadow: var(--elevation-low);
-    transition:
-      border-color var(--interactive-element-transition),
-      box-shadow var(--interactive-element-transition);
+    transition: var(--interactive-element-transition);
   }
 }
-
-*:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-:focus-visible {
-  outline: var(--outline);
-}
-:focus:not(:focus-visible) {
-  outline: none;
-}
+:focus-visible { outline: var(--outline); }
+:focus:not(:focus-visible) { outline: none; }
 a {
   color: var(--color-primary);
   text-decoration: underline;
@@ -331,51 +300,59 @@ a {
     text-decoration: none;
     outline: auto;
   }
-  &:visited {
-    color: var(--color-muted);
-  }
+  &:visited { color: var(--color-muted); }
+}
+::-webkit-search-decoration, /* Remove the inner padding in Chrome and Safari on macOS */
+button, /* Correct the inability to style clickable types in iOS and Safari. */
+[type='button'], [type='reset'], [type='submit'],
+[type='date'], [type='time'], [type='datetime-local'],
+[type='month']  {
+  -webkit-appearance: none;
+  appearance: none;
 }
 
-/*  1. Correct the inability to style clickable types in iOS and Safari. */
+input,
+select,
+textarea,
 button,
-[type="button"],
-[type="reset"],
-[type="submit"] {
-  -webkit-appearance: none; /* 1 */
-  appearance: none; /* 1 */
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  &:hover,
+  &:focus,
+  &:active {
+    box-shadow: var(--elevation-low);
+    transition: var(--interactive-element-transition);
+  }
+}
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
   &:hover,
   &:focus,
   &:active {
     background-color: var(--color-accent);
     color: var(--color-bg);
     border-color: var(--color-primary);
-    box-shadow: var(--elevation-low);
-    transition: var(--interactive-element-transition);
   }
 }
-input,
-select,
-textarea {
-  &:hover,
-  &:focus,
-  &:active {
-    box-shadow: var(--elevation-low);
-    transition: var(--interactive-element-transition);
-  }
+
+button, input, optgroup,
+select, textarea {
+  font-size: 100%;
+  padding: var(--spacing-sm);
+  vertical-align: baseline;
 }
-button,
-input,
-select,
-textarea,
-[type="button"],
-[type="reset"],
-[type="submit"] {
-  overflow: visible;
+label, input, button, select, textarea { 
+  vertical-align: middle; 
+  line-height: inherit;
 }
+/*#endregion*/
+
+/*#region> Dialog */
 /* Does not work in Firefox currently */
-body:has(dialog[open]) {
-  overflow: hidden;
-}
+body:has(dialog[open]) { overflow: hidden; }
 dialog[open] {
   background-color: var(--color-bg);
   border: var(--border);
@@ -393,75 +370,59 @@ dialog[open] {
   justify-self: center;
   align-self: center;
 }
+/*#endregion*/
 
+/*#region> Lists */
+ul, ol, menu { list-style: none; }
+ol { counter-reset: list-counter; }
+ol li::before, ul li::before { font-weight:var(--weight-bold) }
+ol li::before {
+  counter-increment: list-counter;
+  content: counter(list-counter) '. ';
+}
+ul li::before { content: '• '; }
+/*#endregion*/
+
+/*#region> Tables */
+table, th, td {
+  border: var(--border);
+  border-radius: var(--border-radius);
+  padding: var(--spacing-sm);
+  text-align: left;
+}
 table {
   /* Correct table border color inheritance in Chrome and Safari. (https://issues.chromium.org/issues/40615503, https://bugs.webkit.org/show_bug.cgi?id=195016) */
   border-color: currentcolor;
   border-collapse: collapse;
   border-spacing: 0;
   caption-side: bottom;
+  width: 100%;
+  table-layout: fixed;
 }
-
-button,
-input,
-optgroup,
-select,
-textarea {
-  /* Change the font styles in all browsers. */
-  font-family: inherit;
-  font-size: 100%;
-  background-color: inherit;
-  color: inherit;
+caption {
+  font-size: 0.875em;
+  color: var(--color-muted);
   padding: var(--spacing-sm);
-  vertical-align: baseline;
 }
-/* Add the correct display in Chrome and Safari.  */
-summary {
-  display: list-item;
+th, td {
+  border-bottom: var(--border);
+  vertical-align: middle;
 }
-ul,
-ol,
-menu {
-  list-style: none;
+thead th {
+  font-weight: var(--weight-bold);
+  border-bottom: 2px solid var(--color-border);
 }
-ol {
-  counter-reset: list-counter;
-}
-ol li::before {
-  counter-increment: list-counter;
-  font-weight: var(--bold);
-  content: counter(list-counter) ". ";
-}
-ul li::before {
-  content: "• ";
-  font-weight: var(--bold);
-}
-blockquote,
-q {
-  quotes: none;
-}
-progress,
-img,
-svg,
-video,
-canvas,
-audio,
-iframe,
-embed,
-object,
-sub,
-sup {
+/*#endregion*/
+
+/*#region> Mics */
+progress, img, svg, video,
+canvas, audio, iframe,
+embed, object, sub, sup {
   vertical-align: baseline;
   max-width: 100%;
   height: auto;
 }
-label,
-input,
-button,
-select,
-textarea {
-  vertical-align: middle;
-}
+
 img {
   image-rendering: -webkit-optimize-contrast;
   image-rendering: crisp-edges;
@@ -470,39 +431,59 @@ svg {
   display: inline-block;
   fill: currentColor;
 }
-input:not([type="hidden"]),
-textarea,
-select,
-button,
-fieldset,
-meter,
-details,
-dialog,
-table,
-th,
-td {
+input:not([type='hidden']), textarea,
+select, button, fieldset, meter, 
+details, dialog {
   border: var(--border);
   border-radius: var(--border-radius);
   padding: var(--spacing-sm);
 }
-progress {
+progress,
+progress::-moz-progress-bar,
+progress::-webkit-progress-bar {
+  background-color: var(--color-accent);
   border: var(--border);
   border-radius: var(--border-radius);
 }
-legend {
-  font-weight: bold;
+progress{
+  background-color: var(--color-bg);
+}
+legend { 
+  font-weight: var(--weight-bold); 
+  float: left;
+  width: 100%;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
+hr {
+  width: 100%;
+  height: var(--border-width);
+  background-color: var(--color-primary);
 }
+/*#endregion*/
+
+/*#region> Visibility */
+/* Makes the element invisible to screen readers, but remains included in the layout and is still available visually */
+[aria-hidden='true'] { visibility: hidden; }
+/* Hide elements completely (from layout and screen readers) */
+[hidden], [data-hidden], .hidden {
+  display: none;
+  pointer-events: none;
+}
+/* Hide elements visually but keep them available to screen readers */
+[data-hidden='visually'], .visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  overflow: hidden;
+  opacity: 0;
+}
+/*#endregion*/
+
+/*#region> Themes */
 @media (prefers-color-scheme: dark) {
   :root {
     --color-bg: var(--dark-color-bg);
@@ -513,32 +494,53 @@ legend {
     --color-muted: var(--dark-color-muted);
     --color-border: var(--dark-color-border);
     --color-outline: var(--dark-color-outline);
-    --color-shadow: var(--dark-shadow-color);
+    --color-shadow: var(--dark-color-shadow);
   }
 }
-
-/* Makes the element invisible to screen readers, but remains included in the layout and is still available visually */
-[aria-hidden="true"] {
-  visibility: hidden;
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-bg: var(--light-color-bg);
+    --color-fg: var(--light-color-fg);
+    --color-primary: var(--light-color-primary);
+    --color-accent: var(--light-color-accent);
+    --color-emphasis: var(--light-color-emphasis);
+    --color-muted: var(--light-color-muted);
+    --color-border: var(--light-color-border);
+    --color-outline: var(--light-color-outline);
+    --color-shadow: var(--light-shadow-color);
+  }
 }
-/* Hide elements completely (from layout and screen readers) */
-[hidden],
-.hidden,
-[data-hidden] {
-  display: none;
-  pointer-events: none;
+:root[data-theme='dark'] {
+  --color-bg: var(--dark-color-bg);
+  --color-fg: var(--dark-color-fg);
+  --color-primary: var(--dark-color-primary);
+  --color-accent: var(--dark-color-accent);
+  --color-emphasis: var(--dark-color-emphasis);
+  --color-muted: var(--dark-color-muted);
+  --color-border: var(--dark-color-border);
+  --color-outline: var(--dark-color-outline);
+  --color-shadow: var(--dark-color-shadow);
 }
+:root[data-theme='light'] {
+  --color-bg: var(--light-color-bg);
+  --color-fg: var(--light-color-fg);
+  --color-primary: var(--light-color-primary);
+  --color-accent: var(--light-color-accent);
+  --color-emphasis: var(--light-color-emphasis);
+  --color-muted: var(--light-color-muted);
+  --color-border: var(--light-color-border);
+  --color-outline: var(--light-color-outline);
+  --color-shadow: var(--light-shadow-color);
+}
+/*#endregion*/
 
-/* Hide elements visually but keep them available to screen readers */
-.visually-hidden,
-[data-hidden="visually"] {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  clip: rect(0, 0, 0, 0);
-  overflow: hidden;
-  opacity: 0;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,13 +12,13 @@ importers:
         version: 2.29.3
       "@commitlint/cli":
         specifier: ^19.8.0
-        version: 19.8.0(@types/node@22.15.14)(typescript@5.8.3)
+        version: 19.8.0(@types/node@22.15.15)(typescript@5.8.3)
       "@commitlint/config-conventional":
         specifier: ^19.8.0
         version: 19.8.0
       "@commitlint/cz-commitlint":
         specifier: ^19.8.0
-        version: 19.8.0(@types/node@22.15.14)(commitizen@4.3.1(@types/node@22.15.14)(typescript@5.8.3))(inquirer@12.6.0(@types/node@22.15.14))(typescript@5.8.3)
+        version: 19.8.0(@types/node@22.15.15)(commitizen@4.3.1(@types/node@22.15.15)(typescript@5.8.3))(inquirer@12.6.0(@types/node@22.15.15))(typescript@5.8.3)
       "@eslint/eslintrc":
         specifier: ^3.3.1
         version: 3.3.1
@@ -30,25 +30,25 @@ importers:
         version: 0.17.1
       "@types/node":
         specifier: ^22.15.14
-        version: 22.15.14
+        version: 22.15.15
       "@vitest/coverage-v8":
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.1.3)
       "@vitest/ui":
         specifier: 3.1.2
         version: 3.1.2(vitest@3.1.3)
       commitizen:
         specifier: ^4.3.1
-        version: 4.3.1(@types/node@22.15.14)(typescript@5.8.3)
+        version: 4.3.1(@types/node@22.15.15)(typescript@5.8.3)
       dependency-cruiser:
         specifier: ^16.10.1
-        version: 16.10.1
+        version: 16.10.2
       eslint:
         specifier: ^9.26.0
         version: 9.26.0(jiti@2.4.2)
       eslint-config-prettier:
         specifier: ^10.1.2
-        version: 10.1.2(eslint@9.26.0(jiti@2.4.2))
+        version: 10.1.3(eslint@9.26.0(jiti@2.4.2))
       eslint-import-resolver-typescript:
         specifier: ^4.3.4
         version: 4.3.4(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@2.4.2))
@@ -63,10 +63,13 @@ importers:
         version: 9.1.7
       inquirer:
         specifier: ^12.6.0
-        version: 12.6.0(@types/node@22.15.14)
+        version: 12.6.0(@types/node@22.15.15)
       jiti:
         specifier: ^2.4.2
         version: 2.4.2
+      lightningcss:
+        specifier: ^1.29.3
+        version: 1.29.3
       lint-staged:
         specifier: ^15.5.2
         version: 15.5.2
@@ -84,7 +87,7 @@ importers:
         version: 8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
       vitest:
         specifier: ^3.1.3
-        version: 3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1)
+        version: 3.1.3(@types/node@22.15.15)(@vitest/ui@3.1.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
 
   packages/colors:
     dependencies:
@@ -94,19 +97,19 @@ importers:
     devDependencies:
       "@vitest/coverage-v8":
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.1.3)
       vitest:
         specifier: ^3.1.3
-        version: 3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1)
+        version: 3.1.3(@types/node@22.15.15)(@vitest/ui@3.1.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
 
   packages/css-normalize:
     devDependencies:
       "@vitest/coverage-v8":
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.1.3)
       vitest:
         specifier: ^3.1.3
-        version: 3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1)
+        version: 3.1.3(@types/node@22.15.15)(@vitest/ui@3.1.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
 
   packages/css-types: {}
 
@@ -114,10 +117,10 @@ importers:
     devDependencies:
       "@vitest/coverage-v8":
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.1.3)
       vitest:
         specifier: ^3.1.3
-        version: 3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1)
+        version: 3.1.3(@types/node@22.15.15)(@vitest/ui@3.1.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
 
   packages/file:
     dependencies:
@@ -127,10 +130,10 @@ importers:
     devDependencies:
       "@vitest/coverage-v8":
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.1.3)
       vitest:
         specifier: ^3.1.3
-        version: 3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1)
+        version: 3.1.3(@types/node@22.15.15)(@vitest/ui@3.1.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
 
   packages/schema:
     dependencies:
@@ -140,10 +143,10 @@ importers:
     devDependencies:
       "@vitest/coverage-v8":
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.1.3)
       vitest:
         specifier: ^3.1.3
-        version: 3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1)
+        version: 3.1.3(@types/node@22.15.15)(@vitest/ui@3.1.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
 
   packages/text:
     dependencies:
@@ -156,19 +159,19 @@ importers:
     devDependencies:
       "@vitest/coverage-v8":
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.1.3)
       vitest:
         specifier: ^3.1.3
-        version: 3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1)
+        version: 3.1.3(@types/node@22.15.15)(@vitest/ui@3.1.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
 
   packages/utils:
     devDependencies:
       "@vitest/coverage-v8":
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.1.3)
       vitest:
         specifier: ^3.1.3
-        version: 3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1)
+        version: 3.1.3(@types/node@22.15.15)(@vitest/ui@3.1.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
 
 packages:
   "@ampproject/remapping@2.3.0":
@@ -803,10 +806,10 @@ packages:
       }
     engines: { node: ">=18.18" }
 
-  "@humanwhocodes/retry@0.4.2":
+  "@humanwhocodes/retry@0.4.3":
     resolution:
       {
-        integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==,
+        integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
       }
     engines: { node: ">=18.18" }
 
@@ -1320,10 +1323,10 @@ packages:
         integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==,
       }
 
-  "@types/node@22.15.14":
+  "@types/node@22.15.15":
     resolution:
       {
-        integrity: sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==,
+        integrity: sha512-R5muMcZob3/Jjchn5LcO8jdKwSCbzqmPB6ruBxMcf9kbxtniZHP327s6C37iOfuw8mbKK3cAQa7sEl7afLrQ8A==,
       }
 
   "@typescript-eslint/eslint-plugin@8.32.0":
@@ -2299,10 +2302,10 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
-  dependency-cruiser@16.10.1:
+  dependency-cruiser@16.10.2:
     resolution:
       {
-        integrity: sha512-Uw8/emAfzD+Zcua6Hfg1wCnskJd2QSRGKw5tUWrCtA8PBSz+n/zfUYCTjFi9MwdiTA5oecN93FBvh9jJhTLs4A==,
+        integrity: sha512-3tvyt9g3QV6iD6SLC+71bYZnKGTxHo/8dJeguhTgB2T0ui9k/6BbFlibrFYSlb7WeNHS1OlKUFY+BEQ1+w8gvg==,
       }
     engines: { node: ^18.17||>=20 }
     hasBin: true
@@ -2318,6 +2321,13 @@ packages:
     resolution:
       {
         integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==,
+      }
+    engines: { node: ">=8" }
+
+  detect-libc@2.0.4:
+    resolution:
+      {
+        integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==,
       }
     engines: { node: ">=8" }
 
@@ -2510,10 +2520,10 @@ packages:
       }
     engines: { node: ">=10" }
 
-  eslint-config-prettier@10.1.2:
+  eslint-config-prettier@10.1.3:
     resolution:
       {
-        integrity: sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==,
+        integrity: sha512-vDo4d9yQE+cS2tdIT4J02H/16veRvkHgiLDRpej+WL67oCfbOb97itZXn8wMPJ/GsiEBVjrjs//AVNw2Cp1EcA==,
       }
     hasBin: true
     peerDependencies:
@@ -3768,6 +3778,103 @@ packages:
         integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
       }
     engines: { node: ">= 0.8.0" }
+
+  lightningcss-darwin-arm64@1.29.3:
+    resolution:
+      {
+        integrity: sha512-fb7raKO3pXtlNbQbiMeEu8RbBVHnpyqAoxTyTRMEWFQWmscGC2wZxoHzZ+YKAepUuKT9uIW5vL2QbFivTgprZg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.29.3:
+    resolution:
+      {
+        integrity: sha512-KF2XZ4ZdmDGGtEYmx5wpzn6u8vg7AdBHaEOvDKu8GOs7xDL/vcU2vMKtTeNe1d4dogkDdi3B9zC77jkatWBwEQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.29.3:
+    resolution:
+      {
+        integrity: sha512-VUWeVf+V1UM54jv9M4wen9vMlIAyT69Krl9XjI8SsRxz4tdNV/7QEPlW6JASev/pYdiynUCW0pwaFquDRYdxMw==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.29.3:
+    resolution:
+      {
+        integrity: sha512-UhgZ/XVNfXQVEJrMIWeK1Laj8KbhjbIz7F4znUk7G4zeGw7TRoJxhb66uWrEsonn1+O45w//0i0Fu0wIovYdYg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.29.3:
+    resolution:
+      {
+        integrity: sha512-Pqau7jtgJNmQ/esugfmAT1aCFy/Gxc92FOxI+3n+LbMHBheBnk41xHDhc0HeYlx9G0xP5tK4t0Koy3QGGNqypw==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.29.3:
+    resolution:
+      {
+        integrity: sha512-dxakOk66pf7KLS7VRYFO7B8WOJLecE5OPL2YOk52eriFd/yeyxt2Km5H0BjLfElokIaR+qWi33gB8MQLrdAY3A==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.29.3:
+    resolution:
+      {
+        integrity: sha512-ySZTNCpbfbK8rqpKJeJR2S0g/8UqqV3QnzcuWvpI60LWxnFN91nxpSSwCbzfOXkzKfar9j5eOuOplf+klKtINg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.29.3:
+    resolution:
+      {
+        integrity: sha512-3pVZhIzW09nzi10usAXfIGTTSTYQ141dk88vGFNCgawIzayiIzZQxEcxVtIkdvlEq2YuFsL9Wcj/h61JHHzuFQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.29.3:
+    resolution:
+      {
+        integrity: sha512-VRnkAvtIkeWuoBJeGOTrZxsNp4HogXtcaaLm8agmbYtLDOhQdpgxW6NjZZjDXbvGF+eOehGulXZ3C1TiwHY4QQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.29.3:
+    resolution:
+      {
+        integrity: sha512-IszwRPu2cPnDQsZpd7/EAr0x2W7jkaWqQ1SwCVIZ/tSbZVXPLt6k8s6FkcyBjViCzvB5CW0We0QbbP7zp2aBjQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.29.3:
+    resolution:
+      {
+        integrity: sha512-GlOJwTIP6TMIlrTFsxTerwC0W6OpQpCGuX1ECRLBUVRh6fpJH3xTqjCjRgQHTb4ZXexH9rtHou1Lf03GKzmhhQ==,
+      }
+    engines: { node: ">= 12.0.0" }
 
   lilconfig@3.1.3:
     resolution:
@@ -5803,11 +5910,11 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  "@commitlint/cli@19.8.0(@types/node@22.15.14)(typescript@5.8.3)":
+  "@commitlint/cli@19.8.0(@types/node@22.15.15)(typescript@5.8.3)":
     dependencies:
       "@commitlint/format": 19.8.0
       "@commitlint/lint": 19.8.0
-      "@commitlint/load": 19.8.0(@types/node@22.15.14)(typescript@5.8.3)
+      "@commitlint/load": 19.8.0(@types/node@22.15.15)(typescript@5.8.3)
       "@commitlint/read": 19.8.0
       "@commitlint/types": 19.8.0
       tinyexec: 0.3.2
@@ -5826,14 +5933,14 @@ snapshots:
       "@commitlint/types": 19.8.0
       ajv: 8.17.1
 
-  "@commitlint/cz-commitlint@19.8.0(@types/node@22.15.14)(commitizen@4.3.1(@types/node@22.15.14)(typescript@5.8.3))(inquirer@12.6.0(@types/node@22.15.14))(typescript@5.8.3)":
+  "@commitlint/cz-commitlint@19.8.0(@types/node@22.15.15)(commitizen@4.3.1(@types/node@22.15.15)(typescript@5.8.3))(inquirer@12.6.0(@types/node@22.15.15))(typescript@5.8.3)":
     dependencies:
       "@commitlint/ensure": 19.8.0
-      "@commitlint/load": 19.8.0(@types/node@22.15.14)(typescript@5.8.3)
+      "@commitlint/load": 19.8.0(@types/node@22.15.15)(typescript@5.8.3)
       "@commitlint/types": 19.8.0
       chalk: 5.4.1
-      commitizen: 4.3.1(@types/node@22.15.14)(typescript@5.8.3)
-      inquirer: 12.6.0(@types/node@22.15.14)
+      commitizen: 4.3.1(@types/node@22.15.15)(typescript@5.8.3)
+      inquirer: 12.6.0(@types/node@22.15.15)
       lodash.isplainobject: 4.0.6
       word-wrap: 1.2.5
     transitivePeerDependencies:
@@ -5868,7 +5975,7 @@ snapshots:
       "@commitlint/rules": 19.8.0
       "@commitlint/types": 19.8.0
 
-  "@commitlint/load@19.8.0(@types/node@22.15.14)(typescript@5.8.3)":
+  "@commitlint/load@19.8.0(@types/node@22.15.15)(typescript@5.8.3)":
     dependencies:
       "@commitlint/config-validator": 19.8.0
       "@commitlint/execute-rule": 19.8.0
@@ -5876,7 +5983,7 @@ snapshots:
       "@commitlint/types": 19.8.0
       chalk: 5.4.1
       cosmiconfig: 9.0.0(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.15.14)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.15.15)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -6073,29 +6180,29 @@ snapshots:
 
   "@humanwhocodes/retry@0.3.1": {}
 
-  "@humanwhocodes/retry@0.4.2": {}
+  "@humanwhocodes/retry@0.4.3": {}
 
-  "@inquirer/checkbox@4.1.5(@types/node@22.15.14)":
+  "@inquirer/checkbox@4.1.5(@types/node@22.15.15)":
     dependencies:
-      "@inquirer/core": 10.1.10(@types/node@22.15.14)
+      "@inquirer/core": 10.1.10(@types/node@22.15.15)
       "@inquirer/figures": 1.0.11
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
-  "@inquirer/confirm@5.1.9(@types/node@22.15.14)":
+  "@inquirer/confirm@5.1.9(@types/node@22.15.15)":
     dependencies:
-      "@inquirer/core": 10.1.10(@types/node@22.15.14)
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/core": 10.1.10(@types/node@22.15.15)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
-  "@inquirer/core@10.1.10(@types/node@22.15.14)":
+  "@inquirer/core@10.1.10(@types/node@22.15.15)":
     dependencies:
       "@inquirer/figures": 1.0.11
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -6103,93 +6210,93 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
-  "@inquirer/editor@4.2.10(@types/node@22.15.14)":
+  "@inquirer/editor@4.2.10(@types/node@22.15.15)":
     dependencies:
-      "@inquirer/core": 10.1.10(@types/node@22.15.14)
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/core": 10.1.10(@types/node@22.15.15)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
       external-editor: 3.1.0
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
-  "@inquirer/expand@4.0.12(@types/node@22.15.14)":
+  "@inquirer/expand@4.0.12(@types/node@22.15.15)":
     dependencies:
-      "@inquirer/core": 10.1.10(@types/node@22.15.14)
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/core": 10.1.10(@types/node@22.15.15)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
   "@inquirer/figures@1.0.11": {}
 
-  "@inquirer/input@4.1.9(@types/node@22.15.14)":
+  "@inquirer/input@4.1.9(@types/node@22.15.15)":
     dependencies:
-      "@inquirer/core": 10.1.10(@types/node@22.15.14)
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/core": 10.1.10(@types/node@22.15.15)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
-  "@inquirer/number@3.0.12(@types/node@22.15.14)":
+  "@inquirer/number@3.0.12(@types/node@22.15.15)":
     dependencies:
-      "@inquirer/core": 10.1.10(@types/node@22.15.14)
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/core": 10.1.10(@types/node@22.15.15)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
-  "@inquirer/password@4.0.12(@types/node@22.15.14)":
+  "@inquirer/password@4.0.12(@types/node@22.15.15)":
     dependencies:
-      "@inquirer/core": 10.1.10(@types/node@22.15.14)
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/core": 10.1.10(@types/node@22.15.15)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
       ansi-escapes: 4.3.2
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
-  "@inquirer/prompts@7.5.0(@types/node@22.15.14)":
+  "@inquirer/prompts@7.5.0(@types/node@22.15.15)":
     dependencies:
-      "@inquirer/checkbox": 4.1.5(@types/node@22.15.14)
-      "@inquirer/confirm": 5.1.9(@types/node@22.15.14)
-      "@inquirer/editor": 4.2.10(@types/node@22.15.14)
-      "@inquirer/expand": 4.0.12(@types/node@22.15.14)
-      "@inquirer/input": 4.1.9(@types/node@22.15.14)
-      "@inquirer/number": 3.0.12(@types/node@22.15.14)
-      "@inquirer/password": 4.0.12(@types/node@22.15.14)
-      "@inquirer/rawlist": 4.1.0(@types/node@22.15.14)
-      "@inquirer/search": 3.0.12(@types/node@22.15.14)
-      "@inquirer/select": 4.2.0(@types/node@22.15.14)
+      "@inquirer/checkbox": 4.1.5(@types/node@22.15.15)
+      "@inquirer/confirm": 5.1.9(@types/node@22.15.15)
+      "@inquirer/editor": 4.2.10(@types/node@22.15.15)
+      "@inquirer/expand": 4.0.12(@types/node@22.15.15)
+      "@inquirer/input": 4.1.9(@types/node@22.15.15)
+      "@inquirer/number": 3.0.12(@types/node@22.15.15)
+      "@inquirer/password": 4.0.12(@types/node@22.15.15)
+      "@inquirer/rawlist": 4.1.0(@types/node@22.15.15)
+      "@inquirer/search": 3.0.12(@types/node@22.15.15)
+      "@inquirer/select": 4.2.0(@types/node@22.15.15)
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
-  "@inquirer/rawlist@4.1.0(@types/node@22.15.14)":
+  "@inquirer/rawlist@4.1.0(@types/node@22.15.15)":
     dependencies:
-      "@inquirer/core": 10.1.10(@types/node@22.15.14)
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/core": 10.1.10(@types/node@22.15.15)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
-  "@inquirer/search@3.0.12(@types/node@22.15.14)":
+  "@inquirer/search@3.0.12(@types/node@22.15.15)":
     dependencies:
-      "@inquirer/core": 10.1.10(@types/node@22.15.14)
+      "@inquirer/core": 10.1.10(@types/node@22.15.15)
       "@inquirer/figures": 1.0.11
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
-  "@inquirer/select@4.2.0(@types/node@22.15.14)":
+  "@inquirer/select@4.2.0(@types/node@22.15.15)":
     dependencies:
-      "@inquirer/core": 10.1.10(@types/node@22.15.14)
+      "@inquirer/core": 10.1.10(@types/node@22.15.15)
       "@inquirer/figures": 1.0.11
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
-  "@inquirer/type@3.0.6(@types/node@22.15.14)":
+  "@inquirer/type@3.0.6(@types/node@22.15.15)":
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
   "@isaacs/cliui@8.0.2":
     dependencies:
@@ -6368,7 +6475,7 @@ snapshots:
 
   "@types/conventional-commits-parser@5.0.1":
     dependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
   "@types/estree@1.0.7": {}
 
@@ -6378,7 +6485,7 @@ snapshots:
 
   "@types/node@12.20.55": {}
 
-  "@types/node@22.15.14":
+  "@types/node@22.15.15":
     dependencies:
       undici-types: 6.21.0
 
@@ -6512,7 +6619,7 @@ snapshots:
   "@unrs/resolver-binding-win32-x64-msvc@1.7.2":
     optional: true
 
-  "@vitest/coverage-v8@3.0.9(vitest@3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1))":
+  "@vitest/coverage-v8@3.0.9(vitest@3.1.3)":
     dependencies:
       "@ampproject/remapping": 2.3.0
       "@bcoe/v8-coverage": 1.0.2
@@ -6526,7 +6633,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1)
+      vitest: 3.1.3(@types/node@22.15.15)(@vitest/ui@3.1.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6537,13 +6644,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  "@vitest/mocker@3.1.3(vite@6.3.5(@types/node@22.15.14)(jiti@2.4.2)(yaml@2.7.1))":
+  "@vitest/mocker@3.1.3(vite@6.3.5(@types/node@22.15.15)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1))":
     dependencies:
       "@vitest/spy": 3.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.14)(jiti@2.4.2)(yaml@2.7.1)
+      vite: 6.3.5(@types/node@22.15.15)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
 
   "@vitest/pretty-format@3.1.2":
     dependencies:
@@ -6577,7 +6684,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.13
       tinyrainbow: 2.0.0
-      vitest: 3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1)
+      vitest: 3.1.3(@types/node@22.15.15)(@vitest/ui@3.1.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
 
   "@vitest/utils@3.1.2":
     dependencies:
@@ -6871,10 +6978,10 @@ snapshots:
 
   commander@13.1.0: {}
 
-  commitizen@4.3.1(@types/node@22.15.14)(typescript@5.8.3):
+  commitizen@4.3.1(@types/node@22.15.15)(typescript@5.8.3):
     dependencies:
       cachedir: 2.3.0
-      cz-conventional-changelog: 3.3.0(@types/node@22.15.14)(typescript@5.8.3)
+      cz-conventional-changelog: 3.3.0(@types/node@22.15.15)(typescript@5.8.3)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
@@ -6930,9 +7037,9 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@22.15.14)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@22.15.15)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 2.4.2
       typescript: 5.8.3
@@ -6952,16 +7059,16 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cz-conventional-changelog@3.3.0(@types/node@22.15.14)(typescript@5.8.3):
+  cz-conventional-changelog@3.3.0(@types/node@22.15.15)(typescript@5.8.3):
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.1(@types/node@22.15.14)(typescript@5.8.3)
+      commitizen: 4.3.1(@types/node@22.15.15)(typescript@5.8.3)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      "@commitlint/load": 19.8.0(@types/node@22.15.14)(typescript@5.8.3)
+      "@commitlint/load": 19.8.0(@types/node@22.15.15)(typescript@5.8.3)
     transitivePeerDependencies:
       - "@types/node"
       - typescript
@@ -7018,7 +7125,7 @@ snapshots:
 
   depd@2.0.0: {}
 
-  dependency-cruiser@16.10.1:
+  dependency-cruiser@16.10.2:
     dependencies:
       acorn: 8.14.1
       acorn-jsx: 5.3.2(acorn@8.14.1)
@@ -7046,6 +7153,8 @@ snapshots:
   detect-file@1.0.0: {}
 
   detect-indent@6.1.0: {}
+
+  detect-libc@2.0.4: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -7212,7 +7321,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.2(eslint@9.26.0(jiti@2.4.2)):
+  eslint-config-prettier@10.1.3(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.26.0(jiti@2.4.2)
 
@@ -7301,7 +7410,7 @@ snapshots:
       "@eslint/plugin-kit": 0.2.8
       "@humanfs/node": 0.16.6
       "@humanwhocodes/module-importer": 1.0.1
-      "@humanwhocodes/retry": 0.4.2
+      "@humanwhocodes/retry": 0.4.3
       "@modelcontextprotocol/sdk": 1.11.0
       "@types/estree": 1.0.7
       "@types/json-schema": 7.0.15
@@ -7751,17 +7860,17 @@ snapshots:
 
   ini@4.1.1: {}
 
-  inquirer@12.6.0(@types/node@22.15.14):
+  inquirer@12.6.0(@types/node@22.15.15):
     dependencies:
-      "@inquirer/core": 10.1.10(@types/node@22.15.14)
-      "@inquirer/prompts": 7.5.0(@types/node@22.15.14)
-      "@inquirer/type": 3.0.6(@types/node@22.15.14)
+      "@inquirer/core": 10.1.10(@types/node@22.15.15)
+      "@inquirer/prompts": 7.5.0(@types/node@22.15.15)
+      "@inquirer/type": 3.0.6(@types/node@22.15.15)
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
       rxjs: 7.8.2
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
 
   inquirer@8.2.5:
     dependencies:
@@ -8023,6 +8132,51 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lightningcss-darwin-arm64@1.29.3:
+    optional: true
+
+  lightningcss-darwin-x64@1.29.3:
+    optional: true
+
+  lightningcss-freebsd-x64@1.29.3:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.29.3:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.29.3:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.29.3:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.29.3:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.29.3:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.29.3:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.29.3:
+    optional: true
+
+  lightningcss@1.29.3:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.29.3
+      lightningcss-darwin-x64: 1.29.3
+      lightningcss-freebsd-x64: 1.29.3
+      lightningcss-linux-arm-gnueabihf: 1.29.3
+      lightningcss-linux-arm64-gnu: 1.29.3
+      lightningcss-linux-arm64-musl: 1.29.3
+      lightningcss-linux-x64-gnu: 1.29.3
+      lightningcss-linux-x64-musl: 1.29.3
+      lightningcss-win32-arm64-msvc: 1.29.3
+      lightningcss-win32-x64-msvc: 1.29.3
 
   lilconfig@3.1.3: {}
 
@@ -8951,13 +9105,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.1.3(@types/node@22.15.14)(jiti@2.4.2)(yaml@2.7.1):
+  vite-node@3.1.3(@types/node@22.15.15)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.14)(jiti@2.4.2)(yaml@2.7.1)
+      vite: 6.3.5(@types/node@22.15.15)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - "@types/node"
       - jiti
@@ -8972,7 +9126,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@22.15.14)(jiti@2.4.2)(yaml@2.7.1):
+  vite@6.3.5(@types/node@22.15.15)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.4
       fdir: 6.4.4(picomatch@4.0.2)
@@ -8981,15 +9135,16 @@ snapshots:
       rollup: 4.40.2
       tinyglobby: 0.2.13
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
       fsevents: 2.3.3
       jiti: 2.4.2
+      lightningcss: 1.29.3
       yaml: 2.7.1
 
-  vitest@3.1.3(@types/node@22.15.14)(@vitest/ui@3.1.2(vitest@3.1.3))(jiti@2.4.2)(yaml@2.7.1):
+  vitest@3.1.3(@types/node@22.15.15)(@vitest/ui@3.1.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1):
     dependencies:
       "@vitest/expect": 3.1.3
-      "@vitest/mocker": 3.1.3(vite@6.3.5(@types/node@22.15.14)(jiti@2.4.2)(yaml@2.7.1))
+      "@vitest/mocker": 3.1.3(vite@6.3.5(@types/node@22.15.15)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1))
       "@vitest/pretty-format": 3.1.3
       "@vitest/runner": 3.1.3
       "@vitest/snapshot": 3.1.3
@@ -9006,11 +9161,11 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.15.14)(jiti@2.4.2)(yaml@2.7.1)
-      vite-node: 3.1.3(@types/node@22.15.14)(jiti@2.4.2)(yaml@2.7.1)
+      vite: 6.3.5(@types/node@22.15.15)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
+      vite-node: 3.1.3(@types/node@22.15.15)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      "@types/node": 22.15.14
+      "@types/node": 22.15.15
       "@vitest/ui": 3.1.2(vitest@3.1.3)
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
add css compilation to reduce redundancy (lightningcss) and improve semantic organization, add weight prefix to font weight vars (--weight-\*), section/organize css file, updates docs, update build process, add default styling to more elements.

BREAKING CHANGE: font weight vars now use have a --weight-* prefix